### PR TITLE
Fix KeyError when optional columns missing

### DIFF
--- a/classifier/bert_model_training.py
+++ b/classifier/bert_model_training.py
@@ -18,7 +18,7 @@ from transformers import (AutoModel, AutoModelForSequenceClassification,
                           AutoTokenizer, Trainer, TrainingArguments,
                           TrainerCallback)
 
-from preprocess import clean_text, read_data
+from preprocess import clean_text, read_data, read_clean_data
 import logging
 
 s3_client = boto3.client('s3')
@@ -42,9 +42,19 @@ RANDOM_SEED = 913
 
 
 def load_dataset(file_path: str) -> pd.DataFrame:
-    """Load and clean the review dataset from ``file_path``."""
+    """Load the review dataset from ``file_path``.
 
-    df = read_data(file_path)
+    If ``file_path`` points to raw data containing a ``text`` column, the
+    data will be cleaned using :func:`preprocess.read_data`. If the file
+    already contains ``clean_text`` it is loaded directly via
+    :func:`preprocess.read_clean_data`.
+    """
+
+    preview = pd.read_csv(file_path, nrows=1)
+    if "text" in preview.columns:
+        df = read_data(file_path)
+    else:
+        df = read_clean_data(file_path)
     df = df.dropna(subset=["human_tag"])
     return df
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -83,11 +83,31 @@ def clean_text(text):
 def read_data(filepath):
     """Read the CSV from disk."""
     df = pd.read_csv(filepath, delimiter=',')
-    # pandas drop columns using list of column names
-    df = df.drop(['doc_id', 'date', 'title'], axis=1)
+    # Drop optional metadata columns if they exist
+    for col in ["doc_id", "date", "title"]:
+        if col in df.columns:
+            df = df.drop(columns=[col])
     print('Cleaning text')
     df["clean_text"] = df['text'].apply(clean_text)
     print('Number of rows in dataframe: ' + str(len(df.index)))
+    return df
+
+
+def read_clean_data(filepath: str) -> pd.DataFrame:
+    """Read a CSV containing already cleaned reviews.
+
+    The file is expected to contain the columns ``clean_text``, ``star_rating``,
+    and ``human_tag`` as produced by ``preprocess.py``.
+    """
+
+    df = pd.read_csv(filepath, delimiter=',')
+    required_columns = {"clean_text", "star_rating", "human_tag"}
+    missing = required_columns - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"Missing required columns {sorted(missing)} in {filepath}"
+        )
+    print(f"Loaded {len(df.index)} rows from {filepath}")
     return df
 
 def main():


### PR DESCRIPTION
## Summary
- avoid KeyError in `read_data` when dataset lacks optional metadata columns
- add `read_clean_data` for loading already-cleaned CSVs
- detect cleaned vs raw CSVs in `load_dataset`

## Testing
- `python -m py_compile preprocess.py classifier/bert_model_training.py`


------
https://chatgpt.com/codex/tasks/task_e_6867bb6ea87483239a7c1cd49385e987