### PR TITLE
Normalize quoting in cleaned data

### DIFF
--- a/classifier/bert_model_training.py
+++ b/classifier/bert_model_training.py
@@ -19,6 +19,7 @@ from transformers import (AutoModel, AutoModelForSequenceClassification,
                           TrainerCallback)
 
 from preprocess import clean_text, read_data, read_clean_data
+from common import strip_outer_quotes
 import logging
 
 s3_client = boto3.client('s3')
@@ -56,6 +57,7 @@ def load_dataset(file_path: str) -> pd.DataFrame:
     else:
         df = read_clean_data(file_path)
     df = df.dropna(subset=["human_tag"])
+    df["clean_text"] = df["clean_text"].map(strip_outer_quotes)
     return df
 
 

--- a/classifier/rnn_classifier.py
+++ b/classifier/rnn_classifier.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from sklearn.model_selection import train_test_split
 from sklearn.utils import shuffle
 
-from common import getDataFrame
+from common import getDataFrame, strip_outer_quotes
 
 BATCH_SIZE = 64 # 32
 TRAIN_EPOCHS = 15
@@ -190,6 +190,7 @@ def main():
     print("Begin time: ", begin_time_main.strftime("%m/%d/%Y, %H:%M:%S"))
 
     df = getDataFrame("data/24_04_24_21_01_clean_training.csv")
+    df["clean_text"] = df["clean_text"].map(strip_outer_quotes)
     print(df.head())
     df = df.drop(['star_rating'], axis=1)
     df.columns = ['clean_text', 'human_tag']

--- a/classifier/train.py
+++ b/classifier/train.py
@@ -1,4 +1,4 @@
-from common import tokenizeText1
+from common import tokenizeText1, strip_outer_quotes
 
 import os
 import sys
@@ -201,6 +201,7 @@ def testing(features):
         print('Testing file not found in the app path.')
         exit()
     df1 = read_data(testing_filepath)
+    df1["clean_text"] = df1["clean_text"].map(strip_outer_quotes)
     df1 = df1.dropna()
     a = np.array_split(df1,8)
     i = 0

--- a/common.py
+++ b/common.py
@@ -13,6 +13,13 @@ import numpy as np
 import pandas as pd
 import torch
 
+def strip_outer_quotes(text: str) -> str:
+    """Remove leading and trailing double quotes from ``text`` if present."""
+
+    if isinstance(text, str) and text.startswith('"') and text.endswith('"'):
+        return text[1:-1]
+    return text
+
 logger = logging.getLogger(__name__)
 if not logger.handlers:
     logging.basicConfig(level=logging.INFO)

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,5 +1,6 @@
 import datetime
 import pandas as pd
+import csv
 
 import os.path
 import sys, traceback
@@ -80,6 +81,18 @@ def clean_text(text):
     text = cleanr.sub('', fixed_text.strip())
     return remove_stop_words(unicodedata.normalize('NFC', text))
 
+def ensure_surrounding_quotes(text: str) -> str:
+    """Return ``text`` wrapped in double quotes if not already."""
+
+    if not isinstance(text, str):
+        return text
+    stripped = text.strip()
+    if not stripped.startswith('"'):
+        stripped = '"' + stripped
+    if not stripped.endswith('"'):
+        stripped = stripped + '"'
+    return stripped
+
 def read_data(filepath):
     """Read the CSV from disk."""
     df = pd.read_csv(filepath, delimiter=',')
@@ -130,10 +143,17 @@ def main():
     # Format the current time as a string in the "HH:MM" format
     current_time = now.strftime("%y_%m_%d_%H_%M")
     df = read_data(training_filepath)
+    df["clean_text"] = df["clean_text"].apply(ensure_surrounding_quotes)
     header = ["clean_text", "star_rating", "human_tag"]
     output_path = f'data/{current_time}_clean_training.csv'
     print(f"Outputing to {output_path}")
-    df.to_csv(output_path, columns = header, index=False)
+    df.to_csv(
+        output_path,
+        columns=header,
+        index=False,
+        quoting=csv.QUOTE_NONE,
+        escapechar="\\",
+    )
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- ensure every `clean_text` entry is wrapped in quotes when saving cleaned data
- add helper to remove surrounding quotes
- strip quotes in all classifier scripts before training

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'test.py')`


------
https://chatgpt.com/codex/tasks/task_e_6867c50fd0548323aa7db7b20536e602